### PR TITLE
New gravity function

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -198,5 +198,15 @@
     $.fn.tipsy.autoWE = function() {
         return $(this).offset().left > ($(document).scrollLeft() + $(window).width() / 2) ? 'e' : 'w';
     };
-    
+
+    $.fn.tipsy.autoNSedge = function() {
+        var leftOffset = $(this).offset().left;
+        var leftRight = Math.min(leftOffset, $(window).width() - leftOffset);
+        if (leftRight > $(window).width() * 0.05) {
+            return $.fn.tipsy.autoNS.call(this);
+        } else {
+            return $.fn.tipsy.autoNS.call(this) + $.fn.tipsy.autoWE.call(this);
+        }
+    };
+
 })(jQuery);


### PR DESCRIPTION
Hey there,

I've just added a new gravity function that automatically adapts the tooltip gravity depending on the distance to the edge of the screen.

This is similar to `autoNS`, but if the element is near the page edges, it uses a combination between `autoNS` and `autoWE`. This way tooltips are not displayed out of the visible screen space.

If the distance of the current element to the edge of the window is below the 5% of the window width, the combination of `autoNS` and `autoWE` is used.

Currently this value is hard-coded but works quite good. Alternatively I could add an extra option to the gravity function to specify the percentage, and then pass the parameter to `.call()`, but this would need an extra parameter to be used along with the plugin, so not sure what was the best.
