### PR TITLE
New auto gravity function that lays out tooltips in viewable region

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -198,5 +198,30 @@
     $.fn.tipsy.autoWE = function() {
         return $(this).offset().left > ($(document).scrollLeft() + $(window).width() / 2) ? 'e' : 'w';
     };
+
+	$.fn.tipsy.autoBounds = function(margin, prefer) {
+		return function()
+		{
+			var dir = { ns: prefer[0], ew: (prefer.length > 1 ? prefer[1] : false) }
+
+			bound_top = $(document).scrollTop() + margin;
+			bound_left = $(document).scrollLeft() + margin;
+
+			if ( $(this).offset().top < bound_top) {
+				dir.ns = 'n';
+			}
+			if ( $(this).offset().left < bound_left ) {
+				dir.ew = 'w';
+			}
+			if ( $(window).width() + $(document).scrollLeft() - $(this).offset().left < margin ) {
+				dir.ew = 'e';
+			}
+			if ( $(window).height() + $(document).scrollTop() - $(this).offset().top < margin ) {
+				dir.ns = 's';
+			}
+
+			return dir.ns + (dir.ew ? dir.ew : '');
+		}
+	};
     
 })(jQuery);


### PR DESCRIPTION
Added the function:

$.fn.tipsy.autoBounds(margin, prefer)

It takes two parameters:

margin (int) - the distance from the viewable region edge that an element should be before setting its tooltip's gravity to be away from that edge.

prefer (string, of the form 'n', 'sw', 'w', etc) - the direction to prefer if there are no viewable region edges effecting the tooltip's gravity. It will try to vary from this minimally, for example, if 'sw' is preferred and an element is near the right viewable region edge, but not the top edge, it will set the gravity for that element's tooltip to be 'se', preserving the southern component.

$.fn.tispy.autoBounds itself yields a closure of the supplied parameters, producing a function that takes no arguments and is suitable for use as an autogravity function like so:

$('a').tipsy( { gravity: $.fn.tipsy.autoBounds(150, 'nw') } );
