### PR TITLE
Fix for IE6 disappearing content

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -20,7 +20,7 @@
                 
                 $tip.find('.tipsy-inner')[this.options.html ? 'html' : 'text'](title);
                 $tip[0].className = 'tipsy'; // reset classname in case of dynamic gravity
-                $tip.remove().css({top: 0, left: 0, visibility: 'hidden', display: 'block'}).appendTo(document.body);
+                $tip.remove().css({top: 0, left: 0, visibility: 'hidden', display: 'block'}).prependTo(document.body);
                 
                 var pos = $.extend({}, this.$element.offset(), {
                     width: this.$element[0].offsetWidth,


### PR DESCRIPTION
I came across a bizarre issue in IE6 - when the tip was hidden some elements on the page that were position:relative would disappear. I tried to fix this with css by giving the element "hasLayout" thinking it was the peekaboo bug, but none of my attempts worked.

I discovered that this happens when the dom element is removed (this.tip().remove();). Still no clue why, but adding the element with prependTo instead of appendTo solved my issue.
