### PR TITLE
Added ability to set gravity on an element-by-element basis

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,10 @@
+== FORK:
+
+This fork includes support for declaring the gravity on a link using a data attribute. For example:
+
+    <a href="" class="tipsy" data-gravity="sw">Anchor Text</a>
+
+
 tipsy - Facebook-style tooltip plugin for jQuery
 	(c) 2008-2010 Jason Frame (jason@onehackoranother.com)
 	Released under The MIT License.

--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -30,8 +30,8 @@
                 var actualWidth = $tip[0].offsetWidth, actualHeight = $tip[0].offsetHeight;
                 var gravity = (typeof this.options.gravity == 'function')
                                 ? this.options.gravity.call(this.$element[0])
-                                : this.options.gravity;
-                
+                                : (this.$element.data('gravity') || this.options.gravity);
+
                 var tp;
                 switch (gravity.charAt(0)) {
                     case 'n':


### PR DESCRIPTION
Hey,

I needed the ability to choose the gravity applied to the tooltips on many different buttons bit didnt think it was best to call tipsy for each one. Instead I added a data attribute called 'gravity' to each element which seems to work quite well. Use is like so:

```
<a href="#" title="Tooltip text" data-gravity="sw">Anchor Text</a>
```

All the best,
Tom
