### PR TITLE
Made the place to insert the element configurable

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -24,7 +24,12 @@
                 
                 $tip.find('.tipsy-inner')[this.options.html ? 'html' : 'text'](title);
                 $tip[0].className = 'tipsy'; // reset classname in case of dynamic gravity
-                $tip.remove().css({top: 0, left: 0, visibility: 'hidden', display: 'block'})[this.options.insertMethod](this.options.insertTo);
+                
+                var insertTo = this.options.insertTo;
+                if (typeof insertTo == 'function') {
+                  insertTo = insertTo.call(this.$element[0]);
+                };
+                $tip.remove().css({top: 0, left: 0, visibility: 'hidden', display: 'block'})[this.options.insertMethod](insertTo);
                 
                 var pos = $.extend({}, this.$element.offset(), {
                     width: this.$element[0].offsetWidth,

--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -24,7 +24,7 @@
                 
                 $tip.find('.tipsy-inner')[this.options.html ? 'html' : 'text'](title);
                 $tip[0].className = 'tipsy'; // reset classname in case of dynamic gravity
-                $tip.remove().css({top: 0, left: 0, visibility: 'hidden', display: 'block'}).prependTo(document.body);
+                $tip.remove().css({top: 0, left: 0, visibility: 'hidden', display: 'block'})[this.options.insertMethod](this.options.insertTo);
                 
                 var pos = $.extend({}, this.$element.offset(), {
                     width: this.$element[0].offsetWidth,
@@ -59,7 +59,7 @@
                     }
                 }
                 
-                $tip.css(tp).addClass('tipsy-' + gravity);
+                $tip.offset(tp).addClass('tipsy-' + gravity);
                 $tip.find('.tipsy-arrow')[0].className = 'tipsy-arrow tipsy-arrow-' + gravity.charAt(0);
                 if (this.options.className) {
                     $tip.addClass(maybeCall(this.options.className, this.$element[0]));
@@ -188,7 +188,9 @@
         offset: 0,
         opacity: 0.8,
         title: 'title',
-        trigger: 'hover'
+        trigger: 'hover',
+        insertTo: 'body',
+        insertMethod: 'prependTo'
     };
     
     // Overwrite this method to provide options on a per-element basis.


### PR DESCRIPTION
Added two new options for defining where to the tipsy tooltip should be added in the dom tree.

One option, insertTo, defines which element it should be inserted in relation to and the other new option, insertMethod, defines how to add the tooltip.

Code has been added to adjust the position of the tooltip according to the position of the tooltip elements offsetParent - this makes sure that it's always positioned in the right place no matter where in the dom tree it is inserted.

An advantage of adding the tooltip deeper into the dom tree is that it may move together with that content if eg. the position of a common container was to be changed - which eg. happens on a centered site whenever the browser is resized.
