### PR TITLE
Simple viewport edge detection

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -52,9 +52,19 @@
                 }
                 
                 if (gravity.length == 2) {
+                    if (gravity.charAt(1) == 'a') {
+                        var autoDir = '';
+                        if (tp.left < 0) {
+                            autoDir = 'w';
+                        } else if ( tp.left + actualWidth > $(window).width() + $(document).scrollLeft() ) {
+                            autoDir = 'e';
+                        }
+                        gravity = gravity.charAt(0) + autoDir;
+                    }
+
                     if (gravity.charAt(1) == 'w') {
                         tp.left = pos.left + pos.width / 2 - 15;
-                    } else {
+                    } else if (gravity.charAt(1) == 'e') {
                         tp.left = pos.left + pos.width / 2 - actualWidth + 15;
                     }
                 }


### PR DESCRIPTION
I've added another gravity parameter, 'a' (for 'auto'), to be used along with 'n' or 's'.  Since there is no clean way to grab the width of the tooltip div, I've implemented this as a gravity parameter rather than using the gravity callback.  If either the left or right edge of the tooltip falls out of the viewport, the 'e' or 'w' param replaces the 'a', otherwise the 'a' is removed.
