### PR TITLE
Allow mouse to enter tooltip without tooltip disappearing

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -21,8 +21,11 @@
             var title = this.getTitle();
             if (title && this.enabled) {
                 var $tip = this.tip();
+                var $link = $tip.find('.tipsy-inner > a');
                 
-                $tip.find('.tipsy-inner')[this.options.html ? 'html' : 'text'](title);
+                $link.attr('href', this.$element.attr('href'));
+                $link[this.options.html ? 'html' : 'text'](title);
+                
                 $tip[0].className = 'tipsy'; // reset classname in case of dynamic gravity
                 $tip.remove().css({top: 0, left: 0, visibility: 'hidden', display: 'block'}).prependTo(document.body);
                 
@@ -103,7 +106,7 @@
         
         tip: function() {
             if (!this.$tip) {
-                this.$tip = $('<div class="tipsy"></div>').html('<div class="tipsy-arrow"></div><div class="tipsy-inner"></div>');
+                this.$tip = $('<div class="tipsy"></div>').html('<div class="tipsy-arrow"></div><div class="tipsy-inner"><a></a></div>');
             }
             return this.$tip;
         },

--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -4,40 +4,37 @@
 // released under the MIT license
 
 (function($) {
-
+    
     function maybeCall(thing, ctx) {
         return (typeof thing == 'function') ? (thing.call(ctx)) : thing;
     };
-
+    
     function Tipsy(element, options) {
         this.$element = $(element);
         this.options = options;
         this.enabled = true;
         this.fixTitle();
     };
-
+    
     Tipsy.prototype = {
         show: function() {
             var title = this.getTitle();
             if (title && this.enabled) {
                 var $tip = this.tip();
-                var $link = $tip.find('.tipsy-inner > a');
-
-                $link.attr('href', this.$element.attr('href'));
-                $link[this.options.html ? 'html' : 'text'](title);
-
+                
+                $tip.find('.tipsy-inner')[this.options.html ? 'html' : 'text'](title);
                 $tip[0].className = 'tipsy'; // reset classname in case of dynamic gravity
                 $tip.remove().css({top: 0, left: 0, visibility: 'hidden', display: 'block'}).prependTo(document.body);
-
+                
                 var pos = $.extend({}, this.$element.offset(), {
                     width: this.$element[0].offsetWidth,
                     height: this.$element[0].offsetHeight
                 });
-
+                
                 var actualWidth = $tip[0].offsetWidth,
                     actualHeight = $tip[0].offsetHeight,
                     gravity = maybeCall(this.options.gravity, this.$element[0]);
-
+                
                 var tp;
                 switch (gravity.charAt(0)) {
                     case 'n':
@@ -53,7 +50,7 @@
                         tp = {top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left + pos.width + this.options.offset};
                         break;
                 }
-
+                
                 if (gravity.length == 2) {
                     if (gravity.charAt(1) == 'w') {
                         tp.left = pos.left + pos.width / 2 - 15;
@@ -61,13 +58,13 @@
                         tp.left = pos.left + pos.width / 2 - actualWidth + 15;
                     }
                 }
-
+                
                 $tip.css(tp).addClass('tipsy-' + gravity);
                 $tip.find('.tipsy-arrow')[0].className = 'tipsy-arrow tipsy-arrow-' + gravity.charAt(0);
                 if (this.options.className) {
                     $tip.addClass(maybeCall(this.options.className, this.$element[0]));
                 }
-
+                
                 if (this.options.fade) {
                     $tip.stop().css({opacity: 0, display: 'block', visibility: 'visible'}).animate({opacity: this.options.opacity});
                 } else {
@@ -75,7 +72,7 @@
                 }
             }
         },
-
+        
         hide: function() {
             if (this.options.fade) {
                 this.tip().stop().fadeOut(function() { $(this).remove(); });
@@ -83,14 +80,14 @@
                 this.tip().remove();
             }
         },
-
+        
         fixTitle: function() {
             var $e = this.$element;
             if ($e.attr('title') || typeof($e.attr('original-title')) != 'string') {
                 $e.attr('original-title', $e.attr('title') || '').removeAttr('title');
             }
         },
-
+        
         getTitle: function() {
             var title, $e = this.$element, o = this.options;
             this.fixTitle();
@@ -103,14 +100,14 @@
             title = ('' + title).replace(/(^\s*|\s*$)/, "");
             return title || o.fallback;
         },
-
+        
         tip: function() {
             if (!this.$tip) {
-                this.$tip = $('<div class="tipsy"></div>').html('<div class="tipsy-arrow"></div><div class="tipsy-inner"><a></a></div>');
+                this.$tip = $('<div class="tipsy"></div>').html('<div class="tipsy-arrow"></div><div class="tipsy-inner"></div>');
             }
             return this.$tip;
         },
-
+        
         validate: function() {
             if (!this.$element[0].parentNode) {
                 this.hide();
@@ -118,14 +115,14 @@
                 this.options = null;
             }
         },
-
+        
         enable: function() { this.enabled = true; },
         disable: function() { this.enabled = false; },
         toggleEnabled: function() { this.enabled = !this.enabled; }
     };
-
+    
     $.fn.tipsy = function(options) {
-
+        
         if (options === true) {
             return this.data('tipsy');
         } else if (typeof options == 'string') {
@@ -133,9 +130,9 @@
             if (tipsy) tipsy[options]();
             return this;
         }
-
+        
         options = $.extend({}, $.fn.tipsy.defaults, options);
-
+        
         function get(ele) {
             var tipsy = $.data(ele, 'tipsy');
             if (!tipsy) {
@@ -144,18 +141,18 @@
             }
             return tipsy;
         }
-
+        
         function show(tipsy) {
             if (tipsy.mouseInsideTarget || tipsy.mouseInsideTipsy) {
                 tipsy.show();
             }
         }
-
+        
         function delayHide(tipsy) {
             if (tipsy.delayHideTimeout) {
                 return;
             }
-
+            
             // important: setTimeout needed to allow mouse events to fire,
             // e.g. if mouse leaves target but immediately enters tipsy.
             tipsy.delayHideTimeout = setTimeout(function () {
@@ -166,50 +163,50 @@
                 }
             }, options.delayOut || 0);
         }
-
+        
         function enterTarget() {
             var tipsy = get(this);
             tipsy.mouseInsideTarget = true;
-
+            
             if (options.delayIn == 0) {
                 show(tipsy);
             } else {
                 tipsy.fixTitle();
                 setTimeout(function() { show(tipsy); }, options.delayIn);
             }
-
+            
             tipsy.$tip.unbind('mouseenter mouseleave');
             tipsy.$tip.hover(function() { enterTipsy.call(tipsy); }, function() { leaveTipsy.call(tipsy); });
         }
-
+        
         function leaveTarget() {
             var tipsy = get(this);
             tipsy.mouseInsideTarget = false;
             delayHide(tipsy);
         }
-
+        
         function enterTipsy() {
             this.mouseInsideTipsy = true;
         }
-
+        
         function leaveTipsy() {
             this.mouseInsideTipsy = false;
             delayHide(this);
         }
-
+        
         if (!options.live) this.each(function() { get(this); });
-
+        
         if (options.trigger != 'manual') {
             var binder   = options.live ? 'live' : 'bind',
                 eventIn  = options.trigger == 'hover' ? 'mouseenter' : 'focus',
                 eventOut = options.trigger == 'hover' ? 'mouseleave' : 'blur';
             this[binder](eventIn, enterTarget)[binder](eventOut, leaveTarget);
         }
-
+        
         return this;
-
+        
     };
-
+    
     $.fn.tipsy.defaults = {
         className: null,
         delayIn: 0,
@@ -224,7 +221,7 @@
         title: 'title',
         trigger: 'hover'
     };
-
+    
     // Overwrite this method to provide options on a per-element basis.
     // For example, you could store the gravity in a 'tipsy-gravity' attribute:
     // return $.extend({}, options, {gravity: $(ele).attr('tipsy-gravity') || 'n' });
@@ -232,15 +229,15 @@
     $.fn.tipsy.elementOptions = function(ele, options) {
         return $.metadata ? $.extend({}, options, $(ele).metadata()) : options;
     };
-
+    
     $.fn.tipsy.autoNS = function() {
         return $(this).offset().top > ($(document).scrollTop() + $(window).height() / 2) ? 's' : 'n';
     };
-
+    
     $.fn.tipsy.autoWE = function() {
         return $(this).offset().left > ($(document).scrollLeft() + $(window).width() / 2) ? 'e' : 'w';
     };
-
+    
     /**
      * yields a closure of the supplied parameters, producing a function that takes
      * no arguments and is suitable for use as an autogravity function like so:
@@ -251,7 +248,7 @@
      * @param prefer (string, e.g. 'n', 'sw', 'w') - the direction to prefer
      *        if there are no viewable region edges effecting the tooltip's
      *        gravity. It will try to vary from this minimally, for example,
-     *        if 'sw' is preferred and an element is near the right viewable
+     *        if 'sw' is preferred and an element is near the right viewable 
      *        region edge, but not the top edge, it will set the gravity for
      *        that element's tooltip to be 'se', preserving the southern
      *        component.
@@ -271,5 +268,5 @@
 			return dir.ns + (dir.ew ? dir.ew : '');
 		}
 	};
-
+    
 })(jQuery);

--- a/src/stylesheets/tipsy.css
+++ b/src/stylesheets/tipsy.css
@@ -1,5 +1,6 @@
 .tipsy { font-size: 10px; position: absolute; padding: 5px; z-index: 100000; }
-  .tipsy-inner { background-color: #000; color: #FFF; max-width: 200px; padding: 5px 8px 4px 8px; text-align: center; }
+  .tipsy-inner { background-color: #000; max-width: 200px; padding: 5px 8px 4px 8px; text-align: center; }
+    .tipsy-inner > a { display: block; color: #FFF; }
 
   /* Rounded corners */
   .tipsy-inner { border-radius: 3px; -moz-border-radius: 3px; -webkit-border-radius: 3px; }

--- a/src/stylesheets/tipsy.css
+++ b/src/stylesheets/tipsy.css
@@ -1,20 +1,21 @@
 .tipsy { font-size: 10px; position: absolute; padding: 5px; z-index: 100000; }
-  .tipsy-inner { background-color: #000; color: #FFF; max-width: 200px; padding: 5px 8px 4px 8px; text-align: center; }
+  .tipsy-inner { background-color: #000; max-width: 200px; padding: 5px 8px 4px 8px; text-align: center; }
+    .tipsy-inner > a { display: block; color: #FFF; }
 
   /* Rounded corners */
   .tipsy-inner { border-radius: 3px; -moz-border-radius: 3px; -webkit-border-radius: 3px; }
-  
+
   /* Uncomment for shadow */
   /*.tipsy-inner { box-shadow: 0 0 5px #000000; -webkit-box-shadow: 0 0 5px #000000; -moz-box-shadow: 0 0 5px #000000; }*/
-  
+
   .tipsy-arrow { position: absolute; width: 0; height: 0; border: 5px solid transparent; }
-  
+
   /* Rules to colour arrows */
   .tipsy-arrow-n { border-bottom-color: #000; }
   .tipsy-arrow-s { border-top-color: #000; }
   .tipsy-arrow-e { border-left-color: #000; }
   .tipsy-arrow-w { border-right-color: #000; }
-  
+
   .tipsy-n .tipsy-arrow, .tipsy-nw .tipsy-arrow, .tipsy-ne .tipsy-arrow { top: 0; border-top: none; }
   .tipsy-s .tipsy-arrow, .tipsy-sw .tipsy-arrow, .tipsy-se .tipsy-arrow { bottom: 0; border-bottom: none; }
   .tipsy-n .tipsy-arrow, .tipsy-s .tipsy-arrow { left: 50%; margin-left: -5px; }

--- a/src/stylesheets/tipsy.css
+++ b/src/stylesheets/tipsy.css
@@ -1,21 +1,20 @@
 .tipsy { font-size: 10px; position: absolute; padding: 5px; z-index: 100000; }
-  .tipsy-inner { background-color: #000; max-width: 200px; padding: 5px 8px 4px 8px; text-align: center; }
-    .tipsy-inner > a { display: block; color: #FFF; }
+  .tipsy-inner { background-color: #000; color: #FFF; max-width: 200px; padding: 5px 8px 4px 8px; text-align: center; }
 
   /* Rounded corners */
   .tipsy-inner { border-radius: 3px; -moz-border-radius: 3px; -webkit-border-radius: 3px; }
-
+  
   /* Uncomment for shadow */
   /*.tipsy-inner { box-shadow: 0 0 5px #000000; -webkit-box-shadow: 0 0 5px #000000; -moz-box-shadow: 0 0 5px #000000; }*/
-
+  
   .tipsy-arrow { position: absolute; width: 0; height: 0; border: 5px solid transparent; }
-
+  
   /* Rules to colour arrows */
   .tipsy-arrow-n { border-bottom-color: #000; }
   .tipsy-arrow-s { border-top-color: #000; }
   .tipsy-arrow-e { border-left-color: #000; }
   .tipsy-arrow-w { border-right-color: #000; }
-
+  
   .tipsy-n .tipsy-arrow, .tipsy-nw .tipsy-arrow, .tipsy-ne .tipsy-arrow { top: 0; border-top: none; }
   .tipsy-s .tipsy-arrow, .tipsy-sw .tipsy-arrow, .tipsy-se .tipsy-arrow { bottom: 0; border-bottom: none; }
   .tipsy-n .tipsy-arrow, .tipsy-s .tipsy-arrow { left: 50%; margin-left: -5px; }


### PR DESCRIPTION
This lets you select/copy text, interact with HTML content, etc.

It's also needed if you tweak the position of the tooltip (via CSS) to have it overlay the target element instead of go around it; in this case, the former behavior caused the tooltip to flicker if you moused over it.

Since the tooltip now remains visible when you hover over it, we found that we wanted the tooltip text to also link to the same location as the link that the tooltip is for, so we added it too.

This is a resubmission of pull request #53 with the extraneous whitespace changed removed. Thanks for your consideration, and great work on Tipsy!
