### PR TITLE
Allow for overriding tooltip color per instance.

### DIFF
--- a/README
+++ b/README
@@ -41,6 +41,11 @@ Remember to include jquery.tipsy.js *after* including the main jQuery library.
 	});
 </script>
 
+4. To override the default color as set in the jquery.tipsy.js file, simple add the color you want to display in the elements alt tag, e.g.:
+
+<a href="#" rel="tooltip">Default tooltip</a>
+<a href="#" rel="tooltip" alt="#DD4B39">A red tooltip</a>
+
 Please refer to the docs directory for more examples and documentation.
 
 == A NOTE ON FORKING:

--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -21,6 +21,7 @@
             var title = this.getTitle();
             if (title && this.enabled) {
                 var $tip = this.tip();
+	            var $bgColor = this.getBgColor();
                 
                 $tip.find('.tipsy-inner')[this.options.html ? 'html' : 'text'](title);
                 $tip[0].className = 'tipsy'; // reset classname in case of dynamic gravity
@@ -36,18 +37,23 @@
                     gravity = maybeCall(this.options.gravity, this.$element[0]);
                 
                 var tp;
+                var arrowColor;
                 switch (gravity.charAt(0)) {
                     case 'n':
                         tp = {top: pos.top + pos.height + this.options.offset, left: pos.left + pos.width / 2 - actualWidth / 2};
+                        arrowColor = {borderBottomColor: $bgColor};
                         break;
                     case 's':
                         tp = {top: pos.top - actualHeight - this.options.offset, left: pos.left + pos.width / 2 - actualWidth / 2};
+                        arrowColor = {borderTopColor: $bgColor};
                         break;
                     case 'e':
                         tp = {top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left - actualWidth - this.options.offset};
+                        arrowColor = {borderLeftColor: $bgColor};
                         break;
                     case 'w':
                         tp = {top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left + pos.width + this.options.offset};
+                        arrowColor = {borderRightColor: $bgColor};
                         break;
                 }
                 
@@ -58,9 +64,12 @@
                         tp.left = pos.left + pos.width / 2 - actualWidth + 15;
                     }
                 }
-                
+
                 $tip.css(tp).addClass('tipsy-' + gravity);
                 $tip.find('.tipsy-arrow')[0].className = 'tipsy-arrow tipsy-arrow-' + gravity.charAt(0);
+                $tip.find('.tipsy-arrow').css(arrowColor);
+                $tip.find('.tipsy-inner').css({backgroundColor: $bgColor});
+                
                 if (this.options.className) {
                     $tip.addClass(maybeCall(this.options.className, this.$element[0]));
                 }
@@ -99,6 +108,18 @@
             }
             title = ('' + title).replace(/(^\s*|\s*$)/, "");
             return title || o.fallback;
+        },
+        
+        getBgColor: function() {
+        	var bgColor, $e = this.$element, o = this.options;
+
+        	if($e.attr('alt')){
+        		bgColor = $e.attr('alt')
+        	} else {
+        		bgColor = o.bgColor;
+        	}
+
+        	return bgColor;
         },
         
         tip: function() {
@@ -188,7 +209,8 @@
         offset: 0,
         opacity: 0.8,
         title: 'title',
-        trigger: 'hover'
+        trigger: 'hover',
+        bgColor: '#000'
     };
     
     // Overwrite this method to provide options on a per-element basis.

--- a/src/stylesheets/tipsy.css
+++ b/src/stylesheets/tipsy.css
@@ -1,5 +1,5 @@
 .tipsy { font-size: 10px; position: absolute; padding: 5px; z-index: 100000; }
-  .tipsy-inner { background-color: #000; color: #FFF; max-width: 200px; padding: 5px 8px 4px 8px; text-align: center; }
+  .tipsy-inner { color: #FFF; max-width: 200px; padding: 5px 8px 4px 8px; text-align: center; }
 
   /* Rounded corners */
   .tipsy-inner { border-radius: 3px; -moz-border-radius: 3px; -webkit-border-radius: 3px; }
@@ -9,12 +9,6 @@
   
   .tipsy-arrow { position: absolute; width: 0; height: 0; border: 5px solid transparent; }
   
-  /* Rules to colour arrows */
-  .tipsy-arrow-n { border-bottom-color: #000; }
-  .tipsy-arrow-s { border-top-color: #000; }
-  .tipsy-arrow-e { border-left-color: #000; }
-  .tipsy-arrow-w { border-right-color: #000; }
-  
   .tipsy-n .tipsy-arrow, .tipsy-nw .tipsy-arrow, .tipsy-ne .tipsy-arrow { top: 0; border-top: none; }
   .tipsy-s .tipsy-arrow, .tipsy-sw .tipsy-arrow, .tipsy-se .tipsy-arrow { bottom: 0; border-bottom: none; }
   .tipsy-n .tipsy-arrow, .tipsy-s .tipsy-arrow { left: 50%; margin-left: -5px; }
@@ -23,3 +17,5 @@
   .tipsy-e .tipsy-arrow, .tipsy-w .tipsy-arrow { top: 50%; margin-top: -5px; }
   .tipsy-e .tipsy-arrow { right: 0; border-right: none; }
   .tipsy-w .tipsy-arrow { left: 0; border-left: none; }
+
+


### PR DESCRIPTION
By adding color override in alt tag e.g., <a href="#" rel="tooltip"
alt="#DD4B39">A red tooltip</a>
