### PR TITLE
workaround for issue #38, "Live tips not disappearing on mouseout"

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -169,7 +169,16 @@
             var binder   = options.live ? 'live' : 'bind',
                 eventIn  = options.trigger == 'hover' ? 'mouseenter' : 'focus',
                 eventOut = options.trigger == 'hover' ? 'mouseleave' : 'blur';
-            this[binder](eventIn, enter)[binder](eventOut, leave);
+
+			if (options.live) {
+				// title attribute will be removed on first time it sees the element (introduced in #2181b15) create selectors for original-title attribute too
+				var fixed_selector = this.selector.replace(/\[title(.*?\])/, '[original-title$1');
+				$('body').delegate(this.selector+', '+fixed_selector, eventIn, enter);
+				$('body').delegate(this.selector+', '+fixed_selector, eventOut, leave);
+			} else {
+				this.bind(eventIn, enter).bind(eventOut, leave);
+			}
+            
         }
         
         return this;


### PR DESCRIPTION
live element selectors based on "[title]" will be invalid once tipsy sees them since it removes tittle attribute
added a workaround that binds to "[original-title]" too, since that is added.

https://github.com/jaz303/tipsy/issues/38
