### PR TITLE
Adds 'hoverable' trigger: hovered tooltip stays put

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Facebook-style tooltip plugin for jQuery
 
-(c) 2008-2010 Jason Frame (jason@onehackoranother.com)
+(c) 2008-2011 Jason Frame (jason@onehackoranother.com)
 
 Released under The MIT License.
 
@@ -20,7 +20,7 @@ http://onehackoranother.com/projects/jquery/tipsy
 
 Hosted at GitHub; browse at:
 
-  http://github.com/jaz303/tipsy/tree/master
+  <http://github.com/jaz303/tipsy/tree/master>
 
 Or clone from:
 
@@ -28,22 +28,21 @@ Or clone from:
 
 ## Usage:
 
-1. Copy the contents of src/{images,javascripts,stylesheets} to the corresponding asset directories in your project. 
-   If the relative path of your images directory from your stylesheets   directory is not "../images", you'll need to adjust tipsy.css appropriately.
+1. Copy the contents of `src/{javascripts,stylesheets}` to the corresponding asset directories in your project.
 
-2. Insert the neccesary elements in your document's `<head>` section, e.g.:
-   
+2. Insert the necessary elements in your document's `<head>` section, e.g.:
+
         <script type='text/javascript' src='/javascripts/jquery.tipsy.js'></script>
         <link rel="stylesheet" href="/stylesheets/tipsy.css" type="text/css" />
 
  Remember to include jquery.tipsy.js *after* including the main jQuery library.
 
-3. Initialise Tipsy in your document.onload, e.g.:
+3. Initialise Tipsy in your DOM ready handler, e.g.:
 
         <script type='text/javascript'>
-         $(function() {
-	       $('a[rel=tipsy]').tipsy({fade: true, gravity: 'n'});
-	     });
+            $(function() {
+                $('a[rel=tipsy]').tipsy({fade: true, gravity: 'n'});
+            });
         </script>
 
 Please refer to the docs directory for more examples and documentation.

--- a/docs/src/index.html.erb
+++ b/docs/src/index.html.erb
@@ -276,7 +276,7 @@ an anchor tag's title attribute.</p>
   <h3>Hoverable Tooltips</h3>
 
   <p>
-    If you set the trigger to <code>hoverable</code>, the tooltip will stick around if you hover over it, not just if you hover over its element.
+    If you set <code>hoverable: true</code>, the tooltip will stick around if you hover over it or interact with it, not just if you hover/focus its element.
     This can be useful for tooltips containing things like clickable links.
   </p>
   <p>If you don't set a <code>delayOut</code>, it will default to 200.</p>
@@ -288,12 +288,12 @@ an anchor tag's title attribute.</p>
   </p>
 
   <script type='text/javascript'>
-    $('#hoverable-example').tipsy({html: true, trigger:'hoverable'});
+    $('#hoverable-example').tipsy({html: true, hoverable:true});
   </script>
 
   <p>Code:</p>
   <div class='code'><pre>&lt;script type='text/javascript'&gt;
-  $('#hoverable-example').tipsy({html: true, trigger:'hoverable'});
+  $('#hoverable-example').tipsy({html: true, hoverable: true});
 &lt;/script&gt;</pre></div>
 
   
@@ -334,10 +334,11 @@ an anchor tag's title attribute.</p>
     gravity: 'n',     // gravity (string or function)
     html: false,      // is tooltip content HTML?
     live: false,      // use live event support?
+    hoverable: false, // keep tooltip around when hovered/interacted with?
     offset: 0,        // pixel offset of tooltip from element
     opacity: 0.8,     // opacity of tooltip
     title: 'title',   // attribute/callback containing tooltip text
-    trigger: 'hover'  // how tooltip is triggered - hover | focus | manual | hoverable
+    trigger: 'hover'  // how tooltip is triggered - hover | focus | manual
 };</pre></div>
   
   <!-- Notes -->

--- a/docs/src/index.html.erb
+++ b/docs/src/index.html.erb
@@ -270,6 +270,32 @@ an anchor tag's title attribute.</p>
 &lt;script type=&#x27;text/javascript&#x27;&gt;
   $(&#x27;#manual-example a[rel=tipsy]&#x27;).tipsy({trigger: &#x27;manual&#x27;});
 &lt;/script&gt;</pre></div>
+
+  <!-- Hoverable -->
+
+  <h3>Hoverable Tooltips</h3>
+
+  <p>
+    If you set the trigger to <code>hoverable</code>, the tooltip will stick around if you hover over it, not just if you hover over its element.
+    This can be useful for tooltips containing things like clickable links.
+  </p>
+  <p>If you don't set a <code>delayOut</code>, it will default to 200.</p>
+
+  <div class='caption'>Example:</div>
+
+  <p>
+    <a id='hoverable-example' title='I have <a href="#foo">a link</a>' href='#'>Hover me</a>
+  </p>
+
+  <script type='text/javascript'>
+    $('#hoverable-example').tipsy({html: true, trigger:'hoverable'});
+  </script>
+
+  <p>Code:</p>
+  <div class='code'><pre>&lt;script type='text/javascript'&gt;
+  $('#hoverable-example').tipsy({html: true, trigger:'hoverable'});
+&lt;/script&gt;</pre></div>
+
   
   <!-- Live Events Support -->
   
@@ -311,7 +337,7 @@ an anchor tag's title attribute.</p>
     offset: 0,        // pixel offset of tooltip from element
     opacity: 0.8,     // opacity of tooltip
     title: 'title',   // attribute/callback containing tooltip text
-    trigger: 'hover'  // how tooltip is triggered - hover | focus | manual
+    trigger: 'hover'  // how tooltip is triggered - hover | focus | manual | hoverable
 };</pre></div>
   
   <!-- Notes -->

--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -26,14 +26,22 @@
                 $tip[0].className = 'tipsy'; // reset classname in case of dynamic gravity
                 $tip.remove().css({top: 0, left: 0, visibility: 'hidden', display: 'block'}).prependTo(document.body);
 
-                $tip.hover(tipOver, tipOut);
+
+                if (this.options.hoverable) {
+                    $tip.hover(tipOver, tipOut);
+                }
 
                 var that = this;
                 function tipOver() {
-                    that.hoverState = 'in';
+                    that.hoverTooltip = true;
                 }
                 function tipOut() {
-                    that.$element.trigger("mouseleave.tipsy");
+                    if (that.hoverState == 'in') return;  // If field is still focused.
+                    that.hoverTooltip = false;
+                    if (that.options.trigger != 'manual') {
+                        var eventOut = that.options.trigger == 'hover' ? 'mouseleave.tipsy' : 'blur.tipsy';
+                        that.$element.trigger(eventOut);
+                    }
                 }
                 
                 var pos = $.extend({}, this.$element.offset(), {
@@ -142,7 +150,7 @@
         }
         
         options = $.extend({}, $.fn.tipsy.defaults, options);
-        if (options.trigger == 'hoverable') {
+        if (options.hoverable) {
             options.delayOut = options.delayOut || 200;
         }
         
@@ -172,7 +180,7 @@
             if (options.delayOut == 0) {
                 tipsy.hide();
             } else {
-                setTimeout(function() { if (tipsy.hoverState == 'out') tipsy.hide(); }, options.delayOut);
+                setTimeout(function() { if (tipsy.hoverState == 'out' && !tipsy.hoverTooltip) tipsy.hide(); }, options.delayOut);
             }
         };
         
@@ -180,9 +188,8 @@
         
         if (options.trigger != 'manual') {
             var binder   = options.live ? 'live' : 'bind',
-                hoverish = (options.trigger == 'hover' || options.trigger == 'hoverable'),
-                eventIn  = hoverish ? 'mouseenter.tipsy' : 'focus.tipsy',
-                eventOut = hoverish ? 'mouseleave.tipsy' : 'blur.tipsy';
+                eventIn  = options.trigger == 'hover' ? 'mouseenter.tipsy' : 'focus.tipsy',
+                eventOut = options.trigger == 'hover' ? 'mouseleave.tipsy' : 'blur.tipsy';
             this[binder](eventIn, enter)[binder](eventOut, leave);
         }
         
@@ -199,6 +206,7 @@
         gravity: 'n',
         html: false,
         live: false,
+        hoverable: false,
         offset: 0,
         opacity: 0.8,
         title: 'title',

--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -25,6 +25,16 @@
                 $tip.find('.tipsy-inner')[this.options.html ? 'html' : 'text'](title);
                 $tip[0].className = 'tipsy'; // reset classname in case of dynamic gravity
                 $tip.remove().css({top: 0, left: 0, visibility: 'hidden', display: 'block'}).prependTo(document.body);
+
+                $tip.hover(tipOver, tipOut);
+
+                var that = this;
+                function tipOver() {
+                    that.hoverState = 'in';
+                }
+                function tipOut() {
+                    that.$element.trigger("mouseleave.tipsy");
+                }
                 
                 var pos = $.extend({}, this.$element.offset(), {
                     width: this.$element[0].offsetWidth,
@@ -132,6 +142,9 @@
         }
         
         options = $.extend({}, $.fn.tipsy.defaults, options);
+        if (options.trigger == 'hoverable') {
+            options.delayOut = options.delayOut || 200;
+        }
         
         function get(ele) {
             var tipsy = $.data(ele, 'tipsy');
@@ -167,8 +180,9 @@
         
         if (options.trigger != 'manual') {
             var binder   = options.live ? 'live' : 'bind',
-                eventIn  = options.trigger == 'hover' ? 'mouseenter' : 'focus',
-                eventOut = options.trigger == 'hover' ? 'mouseleave' : 'blur';
+                hoverish = (options.trigger == 'hover' || options.trigger == 'hoverable'),
+                eventIn  = hoverish ? 'mouseenter.tipsy' : 'focus.tipsy',
+                eventOut = hoverish ? 'mouseleave.tipsy' : 'blur.tipsy';
             this[binder](eventIn, enter)[binder](eventOut, leave);
         }
         


### PR DESCRIPTION
Useful for tooltips containing links or other stuff to interact with. I'm sure you can think of a more elegant solution, but this appears to work well.
