### PR TITLE
Added ability to select tooltip container via callback or selector option

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -21,12 +21,25 @@
             var title = this.getTitle();
             if (title && this.enabled) {
                 var $tip = this.tip();
-                
+                var container = document.body;
+                var pos = this.$element.offset();
+
+                if (this.options.container != null) {
+                    if (typeof this.options.container == 'string') {
+                        container = $(this.options.container);
+                    } else if (typeof this.options.container == 'function') {
+                        container = this.options.container(this.$element);
+                    }
+                    var posContainer = container.offset();
+                    pos.top -= posContainer.top;
+                    pos.left -= posContainer.left;
+                }
+
                 $tip.find('.tipsy-inner')[this.options.html ? 'html' : 'text'](title);
                 $tip[0].className = 'tipsy'; // reset classname in case of dynamic gravity
-                $tip.remove().css({top: 0, left: 0, visibility: 'hidden', display: 'block'}).prependTo(document.body);
+                $tip.remove().css({top: 0, left: 0, visibility: 'hidden', display: 'block'}).prependTo(container);
                 
-                var pos = $.extend({}, this.$element.offset(), {
+                pos = $.extend({}, pos, {
                     width: this.$element[0].offsetWidth,
                     height: this.$element[0].offsetHeight
                 });
@@ -178,6 +191,7 @@
     
     $.fn.tipsy.defaults = {
         className: null,
+        container: null,
         delayIn: 0,
         delayOut: 0,
         fade: false,


### PR DESCRIPTION
When a tooltip is assigned to an element inside a container that is itself only visible on hover, touching the tooltip with the mouse will close the whole element (happens quite easily). This is because the tooltip is not attached to the DOM node being hovered over, thereby triggering a mouseout on the element we want to keep open.

Example:

``` html
<figure>
    <div class="tools">
       <a class="tooltip" title="Edit image" href="">edit</a>
    </div>
   ...
</figure>
```

``` css
figure div.tools { display: none; }
figure:hover div.tools { display: block; }
```

The solution is to be able to attach the toolttip HTML inside an arbitrary container instead of document.body.

This is now possible with the new "container" option, which takes either a selector string to select a container statically, or a callback function to select the container dynamically, example:

``` javascript
$('a.tooltip').tipsy({container: function(e) {return e.parent().parent();}});
```

Note: this is similar in intention to https://github.com/jaz303/tipsy/pull/47, but uses a more flexible approach IMHO.
