### PR TITLE
Add a global enable/disable for tooltips to be shown.

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -122,6 +122,8 @@
     };
     
     $.fn.tipsy = function(options) {
+
+        $.fn.tipsy.enable();
         
         if (options === true) {
             return this.data('tipsy');
@@ -143,6 +145,9 @@
         }
         
         function enter() {
+            if ($.fn.tipsy.enabled !== true) {
+                return;
+            }
             var tipsy = get(this);
             tipsy.hoverState = 'in';
             if (options.delayIn == 0) {
@@ -190,6 +195,14 @@
         title: 'title',
         trigger: 'hover'
     };
+
+    $.fn.tipsy.enable = function() {
+        $.fn.tipsy.enabled = true;
+    }
+
+    $.fn.tipsy.disable = function() {
+        $.fn.tipsy.enabled = false;
+    }
     
     // Overwrite this method to provide options on a per-element basis.
     // For example, you could store the gravity in a 'tipsy-gravity' attribute:


### PR DESCRIPTION
This allows for temporarily disabling tipsy tooltips. This is useful when you have animations or other situations where tooltips are problematic or cause extra noise.

```
$.fn.tipsy.disable(); // Disable tooltips
$.fn.tipsy.enable();  // Kitten attack! j/k, this turns tooltips back on again.
```
