### PR TITLE
Class name can cause tipsy size to be different

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -23,7 +23,12 @@
                 var $tip = this.tip();
                 
                 $tip.find('.tipsy-inner')[this.options.html ? 'html' : 'text'](title);
+
                 $tip[0].className = 'tipsy'; // reset classname in case of dynamic gravity
+                if (this.options.className) {
+                    $tip.addClass(maybeCall(this.options.className, this.$element[0]));
+                }
+
                 $tip.remove().css({top: 0, left: 0, visibility: 'hidden', display: 'block'}).prependTo(document.body);
                 
                 var pos = $.extend({}, this.$element.offset(), {
@@ -61,9 +66,6 @@
                 
                 $tip.css(tp).addClass('tipsy-' + gravity);
                 $tip.find('.tipsy-arrow')[0].className = 'tipsy-arrow tipsy-arrow-' + gravity.charAt(0);
-                if (this.options.className) {
-                    $tip.addClass(maybeCall(this.options.className, this.$element[0]));
-                }
                 
                 if (this.options.fade) {
                     $tip.stop().css({opacity: 0, display: 'block', visibility: 'visible'}).animate({opacity: this.options.opacity});


### PR DESCRIPTION
If you use the `.className` option in tipsy there is a chance that the user specified class name can cause the size of the tipsy box to be different than if the className is not provided (font size override for example). Right now, tipsy applies the new className **after** it computes the box dimensions, but it should really apply the class **before** it computes the dimensions so that it will end up with the correct results.

This pull request fixes this.
