### PR TITLE
Added Theme Option

### DIFF
--- a/docs/src/index.html.erb
+++ b/docs/src/index.html.erb
@@ -3,6 +3,7 @@
   $(function() {
     
     $('#example-1').tipsy();
+    $('#example-2').tipsy({ theme: ['#00f', 'white'] });
     
     $('#auto-gravity').tipsy({gravity: $.fn.tipsy.autoNS});
     
@@ -97,6 +98,20 @@ an anchor tag's title attribute.</p>
 
 <div class='caption'>Dynamic gravity example:</div>
 <div class='code'><pre>$('#foo').tipsy({gravity: $.fn.tipsy.autoNS});</pre></div>
+
+<h3>Themes</h3>
+
+<p>Using the theme parameter, you can change the design of the tooltip element.</p>
+
+<div class='caption'>Changing the tipsy color theme:</div>
+
+<div class='code'><pre>// use named colors ('black'), hex colors ('#f00'), rgba ('rgba(0,0,255,0.8)'), etc
+// theme: [ background color, text color ]
+$('#example-2').tipsy({ theme: ['#00f', 'white'] });</pre></div>
+
+<p style="background: #333; padding: 40px;">
+ <a id='example-2' href='#' style="color: #fff;" title='Hello World'>Hover over me</a>
+</p>
 
 <h3>Fading</h3>
 

--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -20,9 +20,12 @@
         show: function() {
             var title = this.getTitle();
             if (title && this.enabled) {
-                var $tip = this.tip();
+                var $tip = this.tip(),
+                theme = this.options.theme[0] || 'black',
+                txt = this.options.theme[1] || 'white', 
+                ar;
                 
-                $tip.find('.tipsy-inner')[this.options.html ? 'html' : 'text'](title);
+                $tip.find('.tipsy-inner').css({background:theme,color:txt})[this.options.html ? 'html' : 'text'](title);
                 $tip[0].className = 'tipsy'; // reset classname in case of dynamic gravity
                 $tip.remove().css({top: 0, left: 0, visibility: 'hidden', display: 'block'}).prependTo(document.body);
                 
@@ -39,15 +42,19 @@
                 switch (gravity.charAt(0)) {
                     case 'n':
                         tp = {top: pos.top + pos.height + this.options.offset, left: pos.left + pos.width / 2 - actualWidth / 2};
+                        ar = {'border-bottom-color':theme};
                         break;
                     case 's':
                         tp = {top: pos.top - actualHeight - this.options.offset, left: pos.left + pos.width / 2 - actualWidth / 2};
+                        ar = {'border-top-color':theme};
                         break;
                     case 'e':
                         tp = {top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left - actualWidth - this.options.offset};
+                        ar = {'border-left-color':theme};
                         break;
                     case 'w':
                         tp = {top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left + pos.width + this.options.offset};
+                        ar = {'border-right-color':theme};
                         break;
                 }
                 
@@ -60,7 +67,7 @@
                 }
                 
                 $tip.css(tp).addClass('tipsy-' + gravity);
-                $tip.find('.tipsy-arrow')[0].className = 'tipsy-arrow tipsy-arrow-' + gravity.charAt(0);
+                $tip.find('.tipsy-arrow').css(ar)[0].className = 'tipsy-arrow tipsy-arrow-' + gravity.charAt(0);
                 if (this.options.className) {
                     $tip.addClass(maybeCall(this.options.className, this.$element[0]));
                 }
@@ -188,6 +195,7 @@
         offset: 0,
         opacity: 0.8,
         title: 'title',
+        theme: ['black', 'white'],
         trigger: 'hover'
     };
     

--- a/src/stylesheets/tipsy.css
+++ b/src/stylesheets/tipsy.css
@@ -9,7 +9,7 @@
   
   .tipsy-arrow { position: absolute; width: 0; height: 0; line-height: 0; border: 5px dashed #000; }
   
-  /* Rules to colour arrows */
+  /* Rules to colour arrows, modified by theme option */
   .tipsy-arrow-n { border-bottom-color: #000; }
   .tipsy-arrow-s { border-top-color: #000; }
   .tipsy-arrow-e { border-left-color: #000; }


### PR DESCRIPTION
The theme option is set with the background and text colors and overrides the default css:

``` javascript
$('.selector').tipsy({
    // use named colors ('black'), hex colors ('#f00'), 
    // rgba ('rgba(0,0,255,0.8)'), etc
    // [ background color, text color ]
    theme: [ 'black', 'white' ]
});
```
