### PR TITLE
Added ability to get DOM element via first argument of "title" function

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -89,13 +89,13 @@
         },
         
         getTitle: function() {
-            var title, $e = this.$element, o = this.options;
+            var title, $e = this.$element, o = this.options, e = $e[0];
             this.fixTitle();
             var title, o = this.options;
             if (typeof o.title == 'string') {
                 title = $e.attr(o.title == 'title' ? 'original-title' : o.title);
             } else if (typeof o.title == 'function') {
-                title = o.title.call($e[0]);
+                title = o.title.call(e, e);
             }
             title = ('' + title).replace(/(^\s*|\s*$)/, "");
             return title || o.fallback;


### PR DESCRIPTION
It would be nice if "title" function would take original DOM element as first argument, because it would be very helpful in the case when we need to override original context for instance by using "$.proxy" function:

``` javascript
$('#example-callback').tipsy({title: $.proxy(function(el) { return el.getAttribute('original-title').toUpperCase(); } }, this));
```
