### PR TITLE
Do not call getTitle() if tip is disabled. This way tip can be disabled ...

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -25,8 +25,8 @@
     
     Tipsy.prototype = {
         show: function() {
-            var title = this.getTitle();
-            if (title && this.enabled) {
+            var title;
+            if (this.enabled && (title = this.getTitle())) {
                 var $tip = this.tip();
                 
                 $tip.find('.tipsy-inner')[this.options.html ? 'html' : 'text'](title);


### PR DESCRIPTION
...to avoid unhandled exceptions raised by user-supplied functions. It's a minor optimization, too.
