### PR TITLE
Handle super-long unbroken strings

### DIFF
--- a/src/stylesheets/tipsy.css
+++ b/src/stylesheets/tipsy.css
@@ -1,4 +1,4 @@
-.tipsy { font-size: 10px; position: absolute; padding: 5px; z-index: 100000; }
+.tipsy { font-size: 10px; position: absolute; padding: 5px; word-wrap: break-word; z-index: 100000; }
   .tipsy-inner { background-color: #000; color: #FFF; max-width: 200px; padding: 5px 8px 4px 8px; text-align: center; }
 
   /* Rounded corners */


### PR DESCRIPTION
If your text is long and doesn't have spaces, tipsy just cut it off 
and the right margin would overflow. Now it wraps anyway which looks a bit 
cleaner.

Super nitpick issue. Tipsy is awesome :)

Old
![Problem](http://content.screencast.com/users/AdamAtlassian/folders/Jing/media/84e93b80-f83e-40e4-a018-37b81862d3d5/2012-09-07_1503.png)

New
![Fixed version](http://content.screencast.com/users/AdamAtlassian/folders/Jing/media/ccc9082f-6e21-4baa-b7b1-329f5f543c8e/2012-09-07_1459.png)
