### PR TITLE
Add an appendTo option

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -38,7 +38,7 @@
                     height: this.$element[0].offsetHeight
                 });
                 
-                if(this.options.appendTo != 'body') pos.top = pos.left = 0;
+                if(this.options.appendTo != 'document.body') pos.top = pos.left = 0;
                 
                 var actualWidth = $tip[0].offsetWidth,
                     actualHeight = $tip[0].offsetHeight,
@@ -199,7 +199,7 @@
         opacity: 0.8,
         title: 'title',
         trigger: 'hover',
-        appendTo: 'body'
+        appendTo: 'document.body'
     };
     
     $.fn.tipsy.revalidate = function() {

--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -31,12 +31,14 @@
                 
                 $tip.find('.tipsy-inner')[this.options.html ? 'html' : 'text'](title);
                 $tip[0].className = 'tipsy'; // reset classname in case of dynamic gravity
-                $tip.remove().css({top: 0, left: 0, visibility: 'hidden', display: 'block'}).prependTo(document.body);
+                $tip.remove().css({top: 0, left: 0, visibility: 'hidden', display: 'block'}).prependTo(this.options.appendTo);
                 
                 var pos = $.extend({}, this.$element.offset(), {
                     width: this.$element[0].offsetWidth,
                     height: this.$element[0].offsetHeight
                 });
+                
+                if(this.options.appendTo != 'body') pos.top = pos.left = 0;
                 
                 var actualWidth = $tip[0].offsetWidth,
                     actualHeight = $tip[0].offsetHeight,
@@ -196,7 +198,8 @@
         offset: 0,
         opacity: 0.8,
         title: 'title',
-        trigger: 'hover'
+        trigger: 'hover',
+        appendTo: 'body'
     };
     
     $.fn.tipsy.revalidate = function() {


### PR DESCRIPTION
Added the option "appendTo" that makes it possible to append the tip to
a specific element. Defaults to "body".

This is useful for situations where the tip should follow the element
such as a slider handler.

Example usage:

`$('<div/>')
.slider({
animate: true,
range: "min",
value: 0,
min: 0,
max: 10,
step: 1,
create: function(event, ui){
this.handle = $(this).find('.ui-slider-handle');
this.handle.tipsy({
trigger: 'manual',
appendTo: this.handle
});
},
start: function(event, ui) {
this.handle.tipsy('show');
},
stop: function(event, ui) {
this.handle.tipsy('hide');
}
});`
