### PR TITLE
Add jQuery 1.9 support - removed support for jQuery < 1.7

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -174,10 +174,13 @@
         if (!options.live) this.each(function() { get(this); });
         
         if (options.trigger != 'manual') {
-            var binder   = options.live ? 'live' : 'bind',
-                eventIn  = options.trigger == 'hover' ? 'mouseenter' : 'focus',
+            var eventIn  = options.trigger == 'hover' ? 'mouseenter' : 'focus',
                 eventOut = options.trigger == 'hover' ? 'mouseleave' : 'blur';
-            this[binder](eventIn, enter)[binder](eventOut, leave);
+            if(options.live){
+              $(this.context).on(eventIn, this.selector, enter).on(eventOut, this.selector, leave);
+            } else {
+              this.on(eventIn, enter).on(eventOut, leave);
+            }
         }
         
         return this;


### PR DESCRIPTION
Removed support for jQuery < 1.7 and add support for 1.9

Since .live() is removed from 1.9 use .on() to add dynamic object support
