### PR TITLE
Default to 0 for `offsetWidth` or `offsetHeight`

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -34,12 +34,12 @@
                 $tip.remove().css({top: 0, left: 0, visibility: 'hidden', display: 'block'}).prependTo(document.body);
                 
                 var pos = $.extend({}, this.$element.offset(), {
-                    width: this.$element[0].offsetWidth,
-                    height: this.$element[0].offsetHeight
+                    width: this.$element[0].offsetWidth || 0,
+                    height: this.$element[0].offsetHeight || 0
                 });
                 
-                var actualWidth = $tip[0].offsetWidth,
-                    actualHeight = $tip[0].offsetHeight,
+                var actualWidth = $tip[0].offsetWidth || 0,
+                    actualHeight = $tip[0].offsetHeight || 0,
                     gravity = maybeCall(this.options.gravity, this.$element[0]);
                 
                 var tp;


### PR DESCRIPTION
In firefox an SVG element returns `undefined` when you call `offsetWidth`. It should fallback to 0 (Chrome returns 0).
