### PR TITLE
fix positioning bug in Chrome

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -33,10 +33,7 @@
                 $tip[0].className = 'tipsy'; // reset classname in case of dynamic gravity
                 $tip.remove().css({top: 0, left: 0, visibility: 'hidden', display: 'block'}).prependTo(document.body);
                 
-                var pos = $.extend({}, this.$element.offset(), {
-                    width: this.$element[0].offsetWidth,
-                    height: this.$element[0].offsetHeight
-                });
+                var pos = this.$element[0].getBoundingClientRect();
                 
                 var actualWidth = $tip[0].offsetWidth,
                     actualHeight = $tip[0].offsetHeight,


### PR DESCRIPTION
I've been using this library with D3, and noticed that the tooltips position themselves in the upper left corner of the screen when using Chrome.

`this.$element.offset()` was returning `{ top: 0, left: 0 }`. I'm guessing this has to do with Webkit browsers and the way my D3 plots are rendered.

This branch replaces the call to `$.extend({}, this.$element.offset(), {})` with `this.$element[0].getBoundingClientRect()`. This adds a few extra attributes to the `pos` object, but solves the issue and should work the same.
