### PR TITLE
docs: Fix simple typo, neccesary -> necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Or clone from:
 1. Copy the contents of src/{images,javascripts,stylesheets} to the corresponding asset directories in your project. 
    If the relative path of your images directory from your stylesheets   directory is not "../images", you'll need to adjust tipsy.css appropriately.
 
-2. Insert the neccesary elements in your document's `<head>` section, e.g.:
+2. Insert the necessary elements in your document's `<head>` section, e.g.:
    
         <script type='text/javascript' src='/javascripts/jquery.tipsy.js'></script>
         <link rel="stylesheet" href="/stylesheets/tipsy.css" type="text/css" />


### PR DESCRIPTION
There is a small typo in README.md.

Should read `necessary` rather than `neccesary`.

